### PR TITLE
Sync DNS with a subdomain

### DIFF
--- a/cloudflare_ddns/cloudflare.py
+++ b/cloudflare_ddns/cloudflare.py
@@ -73,7 +73,7 @@ class CloudFlare:
         response = method(
             url,
             headers=self.headers,
-            data=self.process_json_for_cloudflare(data)
+            data=self.process_json_for_cloudflare(data) if data else None
         )
         content = response.json()
         if response.status_code != 200:
@@ -97,7 +97,7 @@ class CloudFlare:
         self.zone = zone
 
         # Initialize dns_records of current zone
-        dns_content = self.request(self.api_url + '/' + zone['id'] + '/dns_records', 'get')
+        dns_content = self.request(self.api_url + zone['id'] + '/dns_records', 'get')
         self.dns_records = dns_content['result']
 
     def refresh(self):
@@ -120,7 +120,7 @@ class CloudFlare:
         except IndexError:
             raise RecordNotFound(
                 'Cannot find the specified dns record in domain {domain}'
-                .format(domain=self.domain))
+                .format(domain=name))
         return record
 
     def create_record(self, dns_type, name, content, **kwargs):
@@ -144,8 +144,8 @@ class CloudFlare:
         else:
             data['proxied'] = True
         content = self.request(
-            urllib.parse.urljoin(self.api_url, self.zone['id'], self.zone['id'] + '/dns_records'),
-            'put',
+            self.api_url + self.zone['id'] + '/dns_records',
+            'post',
             data=data
         )
         print('DNS record successfully created')

--- a/cloudflare_ddns/cloudflare.py
+++ b/cloudflare_ddns/cloudflare.py
@@ -90,7 +90,11 @@ class CloudFlare:
         # Initialize current zone
         zones_content = self.request(self.api_url, 'get')
         try:
-            zone = [zone for zone in zones_content['result'] if zone['name'] == self.domain][0]
+            if len(self.domain.split('.')) == 3:
+                domain = self.domain.split('.', 1)[1]
+            else:
+                domain = self.domain
+            zone = [zone for zone in zones_content['result'] if zone['name'] == domain][0]
         except IndexError:
             raise ZoneNotFound('Cannot find zone information for the domain {domain}.'
                                .format(domain=self.domain))
@@ -238,9 +242,13 @@ class CloudFlare:
         if ip_address == '':
             print('None of public ip finder is working. Please try later')
             sys.exit(1)
-        record = self.get_record(dns_type, self.zone['name'])
+
+        record = self.get_record(dns_type, self.domain) \
+            if len(self.domain.split('.')) == 3 \
+            else self.get_record(dns_type, self.domain)
+
         if record['content'] != ip_address:
-            self.update_record(dns_type, self.zone['name'], ip_address)
+            self.update_record(dns_type, self.domain, ip_address)
             print('Successfully updated IP address from {old_ip} to {new_ip}'
                   .format(old_ip=record['content'], new_ip=ip_address))
         else:


### PR DESCRIPTION
This adds the ability to sync DNS with a subdomain. The implementation in this PR is limited to a single subdomain depth (`sub.example.com` vs `sub.sub.example.com`). The intention is to be able to synchronize a subdomain from the command line.

I also fixed a few bugs to make the code functional (at least in my environment).