### PR TITLE
Expose proxy disabling to the command line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,11 +33,17 @@ Examples
 
         cloudflare-ddns email api_key domain
 
+    - Print command line help
+
+    .. code:: shell
+
+        cloudflare-ddns --help
+
     - Execute python package in command line
 
     .. code:: shell
 
-        python -m cloudflare_ddns email api_key domain
+        python -m cloudflare_ddns email api_key domain --disable_proxied
 
 
     - Python code

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Examples
 
     .. code:: shell
 
-        python -m cloudflare_ddns email api_key domain --disable_proxied
+        python -m cloudflare_ddns email api_key domain --proxied
 
 
     - Python code

--- a/cloudflare_ddns/cloudflare.py
+++ b/cloudflare_ddns/cloudflare.py
@@ -254,7 +254,10 @@ class CloudFlare:
                 if len(self.domain.split('.')) == 3 \
                 else self.get_record(dns_type, self.domain)
         except RecordNotFound:
-            self.create_record(dns_type, self.domain, ip_address)
+            if self.proxied:
+                self.create_record(dns_type, self.domain, ip_address, proxied=True)
+            else:
+                self.create_record(dns_type, self.domain, ip_address)
             print('Successfully created new record with IP address {new_ip}'
                   .format(new_ip=ip_address))
         else:


### PR DESCRIPTION
I thought it'd be quite useful to have the ability to disable a record from being proxied from the command line. If merged, this would expose the flag behind `--disable_proxied` or `-d`.

Something to consider, should a record be proxied by default (the current and functionality of this PR), or not proxied by default? Personally, I think a flag called `--proxied` makes more sense than `--disable_proxied`, but that could just be me 🤷‍♂️